### PR TITLE
Maven Package Creation - v1.0.0

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ windows-2019, ubuntu-latest, macOS-latest ]
+        os: [ windows-2019, ubuntu-20.04, macOS-11 ]
         java-version: [ '8', '11', '17' ]
 
     steps:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,7 +28,7 @@ jobs:
         uses: actions/setup-java@v2
         with:
           java-version: '${{ matrix.java-version }}'
-          distribution: 'adopt'
+          distribution: 'temurin'
 
       - name: Build with Maven
         run: mvn --batch-mode --update-snapshots compile -DskipTests=true

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ windows-2019, ubuntu-20.04, macOS-11 ]
+        os: [ windows-2022, ubuntu-20.04, macOS-11 ]
         java-version: [ '8', '11', '17' ]
 
     steps:
@@ -34,5 +34,5 @@ jobs:
         run: mvn --batch-mode --update-snapshots compile -DskipTests=true
 
       - name: Test with Maven
-        if: ${{ matrix.os == 'windows-2019' && matrix.java-version == '8' }}
+        if: ${{ matrix.os == 'windows-2022' && matrix.java-version == '8' }}
         run: mvn test

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ ubuntu-latest ]
+        os: [ ubuntu-20.04 ]
         java-version: [ '8' ]
         
     steps:

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -32,7 +32,7 @@ jobs:
       uses: actions/setup-java@v2
       with:
         java-version: '${{ matrix.java-version }}'
-        distribution: 'adopt'
+        distribution: 'temurin'
     
     - name: Build with Maven
       run: mvn --batch-mode --update-snapshots compile -DskipTests=true

--- a/.github/workflows/publish-maven-package.yml
+++ b/.github/workflows/publish-maven-package.yml
@@ -1,7 +1,7 @@
 name: Publish Maven Package
 
 env:
-    MAVEN_PACKAGE_VERSION: "1.0.0-SNAPSHOT"
+    MAVEN_PACKAGE_VERSION: "1.0.0"
 
 on:
   workflow_dispatch:

--- a/.github/workflows/publish-maven-package.yml
+++ b/.github/workflows/publish-maven-package.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ ubuntu-latest ]
+        os: [ ubuntu-20.04 ]
         java-version: [ '8' ]
 
     steps:

--- a/README.md
+++ b/README.md
@@ -4,12 +4,15 @@
 [![codecov](https://codecov.io/gh/abhinavminhas/shadowroot-digger-java/branch/main/graph/badge.svg?token=8LXZL9ZLZR)](https://codecov.io/gh/abhinavminhas/shadowroot-digger-java)
 ![maintainer](https://img.shields.io/badge/Creator/Maintainer-abhinavminhas-e65c00)
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](https://opensource.org/licenses/MIT)
+[![Maven Central](https://img.shields.io/maven-central/v/io.github.abhinavminhas/ShadowRoot.Digger?label=Maven%20Central)](https://search.maven.org/search?q=a:ShadowRoot.Digger)
+[![Maven Repository](https://img.shields.io/maven-central/v/io.github.abhinavminhas/ShadowRoot.Digger?label=Maven%20Repository)](https://mvnrepository.com/artifact/io.github.abhinavminhas/ShadowRoot.Digger)  
 
 One of the important aspect of web components is encapsulation and [Shadow DOM API](https://developer.mozilla.org/en-US/docs/Web/Web_Components/Using_shadow_DOM) is a key part of this, allowing hidden DOM trees to be attached to elements in the regular DOM tree. This shadow DOM tree starts with a shadow root, underneath which any elements can be attached, in the same way as the normal DOM. The solution combines the power of [Document Query Selector API](https://developer.mozilla.org/en-US/docs/Web/API/Document/querySelector)  with [Selenium](https://www.selenium.dev/) to grab such shadow root DOM trees and interact with any elements encapsulated within it.
 
 ## Download
-The package is available and can be downloaded using [mvnrepository.com](https://mvnrepository.com/) package manager.  
-- Package Name - [ShadowRoot.Digger](https://mvnrepository.com/).
+The package is available and can be downloaded using [Maven Central Repository Search](https://search.maven.org/) or [MVNRepository](https://mvnrepository.com/) package manager.  
+- Package Name (Maven Central Repository Search) - [ShadowRoot.Digger](https://search.maven.org/search?q=a:ShadowRoot.Digger).
+- Package Name (MVNRepository) - [ShadowRoot.Digger](https://mvnrepository.com/artifact/io.github.abhinavminhas/ShadowRoot.Digger).
 
 ## Features
 1. Returns shadow root or nested shadow root from DOM.
@@ -17,7 +20,7 @@ The package is available and can be downloaded using [mvnrepository.com](https:/
    **NOTE:** *Supports Selenium 3 (Check Selenium Dependency Before Use)*
 
 ## JAVA Supported Versions
-The solution is built on Java 8  
+The solution is built on Java 8.
 
 ## Usage Guidelines
 1. Install the maven package [ShadowRoot.Digger](https://mvnrepository.com/).  
@@ -44,6 +47,7 @@ The solution is built on Java 8
 
    | Google Chrome | Chrome Driver | Microsoft Edge | Edge Driver |
    | ----------- | ----------- | ----------- | ----------- |
+   | 98.0.4758.102 | 98.0.4758.102 | 98.0.1108.56 | 98.0.1108.56 |
    | 97.0.4692.71 | 97.0.4692.71 | 97.0.1072.69 | 97.0.1072.69 |
    | 96.0.4664.110 | 96.0.4664.45 | 96.0.1054.62 | 96.0.1054.62 |
    | 95.0.4638.69 | 95.0.4638.54 | 95.0.1020.53 | 95.0.1020.53 |

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 One of the important aspect of web components is encapsulation and [Shadow DOM API](https://developer.mozilla.org/en-US/docs/Web/Web_Components/Using_shadow_DOM) is a key part of this, allowing hidden DOM trees to be attached to elements in the regular DOM tree. This shadow DOM tree starts with a shadow root, underneath which any elements can be attached, in the same way as the normal DOM. The solution combines the power of [Document Query Selector API](https://developer.mozilla.org/en-US/docs/Web/API/Document/querySelector)  with [Selenium](https://www.selenium.dev/) to grab such shadow root DOM trees and interact with any elements encapsulated within it.
 
 ## Download
-The package is available and can be downloaded using [Maven Central Repository Search](https://search.maven.org/) or [MVNRepository](https://mvnrepository.com/) package manager.  
+The package is available and can be downloaded using [Maven Central Repository Search](https://search.maven.org/)/[MVNRepository](https://mvnrepository.com/) package manager.  
 - Package Name (Maven Central Repository Search) - [ShadowRoot.Digger](https://search.maven.org/search?q=a:ShadowRoot.Digger).
 - Package Name (MVNRepository) - [ShadowRoot.Digger](https://mvnrepository.com/artifact/io.github.abhinavminhas/ShadowRoot.Digger).
 

--- a/pom.xml
+++ b/pom.xml
@@ -46,7 +46,7 @@
 		<maven.compiler.target>1.8</maven.compiler.target>
 		<maven.surefire.plugin.version>3.0.0-M5</maven.surefire.plugin.version>
 		<jacoco.maven.plugin.version>0.8.7</jacoco.maven.plugin.version>
-		<nexus.staging.maven.plugin.version>1.6.11</nexus.staging.maven.plugin.version>
+		<nexus.staging.maven.plugin.version>1.6.7</nexus.staging.maven.plugin.version>
 		<maven.source.plugin.version>3.2.1</maven.source.plugin.version>
 		<maven.javadoc.plugin.version>3.3.2</maven.javadoc.plugin.version>
 		<maven.gpg.plugin.version>1.6</maven.gpg.plugin.version>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>io.github.abhinavminhas</groupId>
 	<artifactId>ShadowRoot.Digger</artifactId>
-	<version>1.0.0-SNAPSHOT</version>
+	<version>1.0.0</version>
 
 	<name>ShadowRoot.Digger</name>
 	<description>DOM shadow root elements finder using Selenium solution in JAVA.</description>

--- a/src/test/java/helper/TestBase.java
+++ b/src/test/java/helper/TestBase.java
@@ -21,7 +21,7 @@ import io.github.bonigarcia.wdm.WebDriverManager;
 public class TestBase {
 
 	protected WebDriver webDriver;
-	private String chromeDriverVersion = "97.0.4692.71";
+	private String chromeDriverVersion = "98.0.4758.102";
 	protected static final String CHROME_SETTINGS_TESTS = "CHROME-SETTINGS-TESTS";
 	protected static final String SHADOW_DOM_HTML_TESTS = "SHADOW-DOM-HTML-TESTS";
 	protected static Properties config;


### PR DESCRIPTION
- Maven Package Creation - v1.0.0.
- Version specific 'OS' tag updates in Github workflow files.
- Broken nexus staging maven plugin version fix.
- Java distribution change from 'adopt' to 'temurin'.
- Windows tag update to '2022' and chromedriver update to '98.0.4758.102'.
- Readme updates.