### PR TITLE
Maven Package Creation - v2.0.3

### DIFF
--- a/.github/workflows/publish-maven-package.yml
+++ b/.github/workflows/publish-maven-package.yml
@@ -1,7 +1,7 @@
 name: Publish Maven Package
 
 env:
-    MAVEN_PACKAGE_VERSION: "2.0.2"
+    MAVEN_PACKAGE_VERSION: "2.0.3"
 
 on:
   workflow_dispatch:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,21 +3,21 @@ All notable changes to this project documented here.
 
 ## [Released]
 
-## [2.0.2](https://search.maven.org/artifact/io.github.abhinavminhas/ShadowRoot.Digger/2.0.2/jar) - 2021-03-14
+## [2.0.2](https://mvnrepository.com/artifact/io.github.abhinavminhas/ShadowRoot.Digger/2.0.2) - 2021-03-14
 ### Changed
 - Bumped Selenium version from '4.1.0' to '4.1.1'.
 
 ### Notes
 - This version supports change in shadow root return values for Selenium in Chromium browsers (Google Chrome and Microsoft Edge) v96 and is backward compatible.
 
-## [2.0.1](https://search.maven.org/artifact/io.github.abhinavminhas/ShadowRoot.Digger/2.0.1/jar) - 2021-03-12
+## [2.0.1](https://mvnrepository.com/artifact/io.github.abhinavminhas/ShadowRoot.Digger/2.0.1) - 2021-03-12
 ### Changed
 - Bumped Selenium version from '4.0.0' to '4.1.0'.
 
 ### Notes
 - This version supports change in shadow root return values for Selenium in Chromium browsers (Google Chrome and Microsoft Edge) v96 and is backward compatible.
 
-## [2.0.0](https://search.maven.org/artifact/io.github.abhinavminhas/ShadowRoot.Digger/2.0.0/jar) - 2021-03-08
+## [2.0.0](https://mvnrepository.com/artifact/io.github.abhinavminhas/ShadowRoot.Digger/2.0.0) - 2021-03-08
 ### Changed
 - ShadowRootAssist methods *getShadowRootElement()* & *getNestedShadowRootElement()* now return '*SearchContext*' instead of '*WebElement*' which can be used to search elements encapsulated within.
 - Changed use of web driver wait *```WebDriverWait(WebDriver driver, long timeOutInSeconds, long sleepInMillis)```* to *```WebDriverWait(WebDriver driver, Duration timeout, Duration sleep)```* due to deprecation of former in the new Selenium version.
@@ -25,7 +25,7 @@ All notable changes to this project documented here.
 ### Notes
 - This version supports change in shadow root return values for Selenium in Chromium browsers (Google Chrome and Microsoft Edge) v96 and is backward compatible.
 
-## [1.0.0](https://search.maven.org/artifact/io.github.abhinavminhas/ShadowRoot.Digger/1.0.0/jar) - 2021-02-22
+## [1.0.0](https://mvnrepository.com/artifact/io.github.abhinavminhas/ShadowRoot.Digger/1.0.0) - 2021-02-22
 ### Added
 - Shadow root digger implementation.
   - ShadowRootAssist.getShadowRootElement()

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,21 +3,28 @@ All notable changes to this project documented here.
 
 ## [Released]
 
-## [2.0.2](https://mvnrepository.com/artifact/io.github.abhinavminhas/ShadowRoot.Digger/2.0.2) - 2021-03-14
+## [2.0.3](https://mvnrepository.com/artifact/io.github.abhinavminhas/ShadowRoot.Digger/2.0.3) - 2022-03-16
+### Changed
+- Bumped Selenium version from '4.1.1' to '4.1.2'.
+
+### Notes
+- This version supports change in shadow root return values for Selenium in Chromium browsers (Google Chrome and Microsoft Edge) v96 and is backward compatible.
+
+## [2.0.2](https://mvnrepository.com/artifact/io.github.abhinavminhas/ShadowRoot.Digger/2.0.2) - 2022-03-14
 ### Changed
 - Bumped Selenium version from '4.1.0' to '4.1.1'.
 
 ### Notes
 - This version supports change in shadow root return values for Selenium in Chromium browsers (Google Chrome and Microsoft Edge) v96 and is backward compatible.
 
-## [2.0.1](https://mvnrepository.com/artifact/io.github.abhinavminhas/ShadowRoot.Digger/2.0.1) - 2021-03-12
+## [2.0.1](https://mvnrepository.com/artifact/io.github.abhinavminhas/ShadowRoot.Digger/2.0.1) - 2022-03-12
 ### Changed
 - Bumped Selenium version from '4.0.0' to '4.1.0'.
 
 ### Notes
 - This version supports change in shadow root return values for Selenium in Chromium browsers (Google Chrome and Microsoft Edge) v96 and is backward compatible.
 
-## [2.0.0](https://mvnrepository.com/artifact/io.github.abhinavminhas/ShadowRoot.Digger/2.0.0) - 2021-03-08
+## [2.0.0](https://mvnrepository.com/artifact/io.github.abhinavminhas/ShadowRoot.Digger/2.0.0) - 2022-03-08
 ### Changed
 - ShadowRootAssist methods *getShadowRootElement()* & *getNestedShadowRootElement()* now return '*SearchContext*' instead of '*WebElement*' which can be used to search elements encapsulated within.
 - Changed use of web driver wait *```WebDriverWait(WebDriver driver, long timeOutInSeconds, long sleepInMillis)```* to *```WebDriverWait(WebDriver driver, Duration timeout, Duration sleep)```* due to deprecation of former in the new Selenium version.
@@ -25,7 +32,7 @@ All notable changes to this project documented here.
 ### Notes
 - This version supports change in shadow root return values for Selenium in Chromium browsers (Google Chrome and Microsoft Edge) v96 and is backward compatible.
 
-## [1.0.0](https://mvnrepository.com/artifact/io.github.abhinavminhas/ShadowRoot.Digger/1.0.0) - 2021-02-22
+## [1.0.0](https://mvnrepository.com/artifact/io.github.abhinavminhas/ShadowRoot.Digger/1.0.0) - 2022-02-22
 ### Added
 - Shadow root digger implementation.
   - ShadowRootAssist.getShadowRootElement()

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>io.github.abhinavminhas</groupId>
 	<artifactId>ShadowRoot.Digger</artifactId>
-	<version>2.0.3-SNAPSHOT</version>
+	<version>2.0.3</version>
 
 	<name>ShadowRoot.Digger</name>
 	<description>DOM shadow root elements finder using Selenium solution in JAVA.</description>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>io.github.abhinavminhas</groupId>
 	<artifactId>ShadowRoot.Digger</artifactId>
-	<version>2.0.2</version>
+	<version>2.0.3-SNAPSHOT</version>
 
 	<name>ShadowRoot.Digger</name>
 	<description>DOM shadow root elements finder using Selenium solution in JAVA.</description>
@@ -36,7 +36,7 @@
 		<project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 
 		<!-- Dependency artifact versions -->
-		<selenium.java.version>4.1.1</selenium.java.version>
+		<selenium.java.version>4.1.2</selenium.java.version>
 		<webdrivermanager.version>5.1.0</webdrivermanager.version>
 		<testng.version>7.5</testng.version>
 

--- a/src/main/java/io/github/abhinavminhas/ShadowRootAssist.java
+++ b/src/main/java/io/github/abhinavminhas/ShadowRootAssist.java
@@ -12,7 +12,7 @@ import org.openqa.selenium.support.ui.WebDriverWait;
  * 'ShadowRootAssist' class to support digging of shadow roots in DOM.
  * 
  * @author 	Abhinav Minhas
- * @version 2.0.2
+ * @version 2.0.3
  * @since 	01-01-2022
  */
 public class ShadowRootAssist {


### PR DESCRIPTION
- Bump Selenium version from '4.1.1' to '4.1.2'.
- Changelog - Changed version links from 'search.maven.org' to 'mvnrepository.com'.
- Changelog - Date corrections.
- Maven Package Creation - v2.0.3.